### PR TITLE
feat: remove attractions section and implement Unsplash API integration

### DIFF
--- a/project/src/components/CountryDetailSimple.tsx
+++ b/project/src/components/CountryDetailSimple.tsx
@@ -5,8 +5,6 @@ import CountryFlag from './CountryFlag';
 import InteractiveWorldMap from './InteractiveWorldMap';
 import { getCountryImage } from '../data/countryImages';
 import { countryData } from '../data/countries';
-import { getHighlightImage } from '../data/countryHighlightImages';
-import type { CountryHighlight } from '../../../../shared/types';
 
 export default function CountryDetailSimple() {
   const { countryCode } = useParams<{ countryCode: string }>();
@@ -162,39 +160,6 @@ export default function CountryDetailSimple() {
                 </div>
               </div>
 
-              {/* Highlights */}
-              <div className="bg-white/10 backdrop-blur-md rounded-3xl p-8 border border-white/20 shadow-2xl">
-                <h3 className="text-xl font-bold text-white mb-6 flex items-center gap-2">
-                  <Sparkles className="w-5 h-5 text-purple-300" />
-                  {country.name}の魅力
-                </h3>
-                <div className="grid md:grid-cols-2 gap-4">
-                  {country.highlights.map((highlight: CountryHighlight, index: number) => (
-                    <div key={index} className="bg-white/10 backdrop-blur-sm rounded-xl border border-white/20 overflow-hidden hover:bg-white/15 transition-all duration-300">
-                      <div className="flex">
-                        {/* 左側：画像 */}
-                        <div className="w-40 h-32 flex-shrink-0 bg-white/10">
-                          <img 
-                            src={getHighlightImage(highlight.title, countryCode || '')} 
-                            alt={highlight.title}
-                            className="w-full h-full object-cover"
-                            crossOrigin="anonymous"
-                            onError={(e) => {
-                              const target = e.target as HTMLImageElement;
-                              target.src = 'https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=400&h=300&fit=crop&q=80';
-                            }}
-                          />
-                        </div>
-                        {/* 右側：テキスト */}
-                        <div className="flex-1 p-4">
-                          <h4 className="font-bold text-white mb-2">{highlight.title}</h4>
-                          <p className="text-white/80 text-sm leading-relaxed">{highlight.description}</p>
-                        </div>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              </div>
 
               {/* Call to Action */}
               <div className="text-center">

--- a/project/src/data/countryImages.ts
+++ b/project/src/data/countryImages.ts
@@ -1,57 +1,16 @@
-// 各国の厳選された美しい画像URL
-// 各国の厳選された美しい画像URL（すべてHTTPS対応）
-export const countryImages: Record<string, string> = {
-  // メジャー国
-  'korea': 'https://images.unsplash.com/photo-1517154421773-0529f29ea451?w=1200&h=800&fit=crop&q=80', // ソウル夜景
-  'japan': 'https://images.unsplash.com/photo-1490650034439-fd184c3c86a5?w=1200&h=800&fit=crop&q=80', // 富士山と桜
-  'usa': 'https://images.unsplash.com/photo-1485738422979-f5c462d49f74?w=1200&h=800&fit=crop&q=80', // ニューヨーク
-  'france': 'https://images.unsplash.com/photo-1502602898536-47ad22581b52?w=1200&h=800&fit=crop&q=80', // エッフェル塔
-  'italy': 'https://images.unsplash.com/photo-1515542622106-78bda8ba0e5b?w=1200&h=800&fit=crop&q=80', // ベニス
-  'china': 'https://images.unsplash.com/photo-1508804185872-d7badad00f7d?w=1200&h=800&fit=crop&q=80', // 万里の長城
-  'germany': 'https://images.unsplash.com/photo-1467269204594-9661b134dd2b?w=1200&h=800&fit=crop&q=80', // ノイシュヴァンシュタイン城
-  'uk': 'https://images.unsplash.com/photo-1513635269975-59663e0ac1ad?w=1200&h=800&fit=crop&q=80', // ロンドン
-  
-  // 中堅国
-  'finland': 'https://images.unsplash.com/photo-1507272931001-fc06c17e4f43?w=1200&h=800&fit=crop&q=80', // オーロラ
-  'thailand': 'https://images.unsplash.com/photo-1520637836862-4d197d17c13a?w=1200&h=800&fit=crop', // タイの寺院
-  'vietnam': 'https://images.unsplash.com/photo-1557750255-c76072a7aad1?w=1200&h=800&fit=crop', // ハロン湾
-  'mexico': 'https://images.unsplash.com/photo-1518105779142-d975f22f1b0a?w=1200&h=800&fit=crop', // チチェン・イッツァ
-  'brazil': 'https://images.unsplash.com/photo-1483729558449-99ef09a8c325?w=1200&h=800&fit=crop', // リオ キリスト像
-  'india': 'https://images.unsplash.com/photo-1564507592333-c60657eea523?w=1200&h=800&fit=crop', // タージマハル
-  'australia': 'https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=1200&h=800&fit=crop', // シドニー オペラハウス
-  'canada': 'https://images.unsplash.com/photo-1503614472-8c93d56e92ce?w=1200&h=800&fit=crop', // バンフ国立公園
-  'spain': 'https://images.unsplash.com/photo-1539037116277-4db20889f2d4?w=1200&h=800&fit=crop', // サグラダファミリア
-  'netherlands': 'https://images.unsplash.com/photo-1534351590666-13e3e96b5017?w=1200&h=800&fit=crop', // アムステルダム運河
-  'algeria': 'https://images.unsplash.com/photo-1563567930045-a3b5b4a8b2dc?w=1200&h=800&fit=crop&q=80', // サハラ砂漠
-  
-  // マイナー国
-  'bhutan': 'https://images.unsplash.com/photo-1609156239782-0b9c3b35ecf0?w=1200&h=800&fit=crop', // タイガーズネスト僧院
-  'maldives': 'https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=1200&h=800&fit=crop', // モルディブビーチ
-  'iceland': 'https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=1200&h=800&fit=crop', // アイスランド氷河
-  'malta': 'https://images.unsplash.com/photo-1582719201952-2c3b9c88b3f1?w=1200&h=800&fit=crop', // マルタ ヴァレッタ
-  'luxembourg': 'https://images.unsplash.com/photo-1571115764595-644a1f56a55c?w=1200&h=800&fit=crop', // ルクセンブルク城
-  'brunei': 'https://images.unsplash.com/photo-1561114120-9b0c60e4f82a?w=1200&h=800&fit=crop', // ブルネイ モスク
-  'montenegro': 'https://images.unsplash.com/photo-1545558014-8692077e9b5c?w=1200&h=800&fit=crop', // コトル湾
-  'estonia': 'https://images.unsplash.com/photo-1539650116574-75c0c6d75d24?w=1200&h=800&fit=crop', // タリン旧市街
-  'latvia': 'https://images.unsplash.com/photo-1529963183134-61a90db47eaf?w=1200&h=800&fit=crop', // リガ旧市街
-  'lithuania': 'https://images.unsplash.com/photo-1469474968028-56623f02e42e?w=1200&h=800&fit=crop', // ヴィリニュス旧市街
-  'slovenia': 'https://images.unsplash.com/photo-1520637836862-4d197d17c13a?w=1200&h=800&fit=crop', // ブレッド湖
-  'cyprus': 'https://images.unsplash.com/photo-1605540436563-5bca919ae766?w=1200&h=800&fit=crop', // キプロス海岸
-  'andorra': 'https://images.unsplash.com/photo-1469474968028-56623f02e42e?w=1200&h=800&fit=crop', // アンドラ山景
-  'san-marino': 'https://images.unsplash.com/photo-1578662996442-48f60103fc96?w=1200&h=800&fit=crop', // サンマリノ塔
-  'monaco': 'https://images.unsplash.com/photo-1582719201952-2c3b9c88b3f1?w=1200&h=800&fit=crop', // モナコ港
-  'vatican': 'https://images.unsplash.com/photo-1448932223592-d1fc686e76ea?w=1200&h=800&fit=crop', // バチカン
-  'seychelles': 'https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=1200&h=800&fit=crop', // セーシェル ビーチ
-  'palau': 'https://images.unsplash.com/photo-1559827260-dc66d52bef19?w=1200&h=800&fit=crop', // パラオ ジェリーフィッシュレイク
-  'tuvalu': 'https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=1200&h=800&fit=crop', // ツバル環礁
-  'nauru': 'https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=1200&h=800&fit=crop', // ナウル島
-  'kiribati': 'https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=1200&h=800&fit=crop', // キリバス環礁
-  'marshall-islands': 'https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=1200&h=800&fit=crop', // マーシャル諸島
-  'micronesia': 'https://images.unsplash.com/photo-1559827260-dc66d52bef19?w=1200&h=800&fit=crop', // ミクロネシア
-  'tonga': 'https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=1200&h=800&fit=crop', // トンガ
-  'samoa': 'https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=1200&h=800&fit=crop', // サモア
-  'vanuatu': 'https://images.unsplash.com/photo-1559827260-dc66d52bef19?w=1200&h=800&fit=crop', // バヌアツ火山
-  'fiji': 'https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=1200&h=800&fit=crop', // フィジー
+import { getCountryImageWithFallback } from '../services/unsplashService';
+import { countryData } from './countries';
+
+// Backup static images for critical countries (used as fallback if Unsplash fails)
+export const staticCountryImages: Record<string, string> = {
+  'korea': 'https://images.unsplash.com/photo-1517154421773-0529f29ea451?w=1200&h=800&fit=crop&q=80',
+  'japan': 'https://images.unsplash.com/photo-1490650034439-fd184c3c86a5?w=1200&h=800&fit=crop&q=80',
+  'usa': 'https://images.unsplash.com/photo-1485738422979-f5c462d49f74?w=1200&h=800&fit=crop&q=80',
+  'france': 'https://images.unsplash.com/photo-1502602898536-47ad22581b52?w=1200&h=800&fit=crop&q=80',
+  'italy': 'https://images.unsplash.com/photo-1515542622106-78bda8ba0e5b?w=1200&h=800&fit=crop&q=80',
+  'china': 'https://images.unsplash.com/photo-1508804185872-d7badad00f7d?w=1200&h=800&fit=crop&q=80',
+  'germany': 'https://images.unsplash.com/photo-1467269204594-9661b134dd2b?w=1200&h=800&fit=crop&q=80',
+  'uk': 'https://images.unsplash.com/photo-1513635269975-59663e0ac1ad?w=1200&h=800&fit=crop&q=80',
 };
 
 // フォールバック画像（国の画像が見つからない場合）
@@ -59,7 +18,25 @@ export const getFallbackImage = (): string => {
   return `https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=1200&h=800&fit=crop&q=80`;
 };
 
-// 画像取得関数
+// 画像取得関数 - 動的にUnsplashから国別画像を取得
 export const getCountryImage = (countryCode: string): string => {
-  return countryImages[countryCode.toLowerCase()] || getFallbackImage();
+  try {
+    // まず国データから国名を取得
+    const country = countryData[countryCode.toLowerCase()];
+    if (!country) {
+      return getFallbackImage();
+    }
+
+    // 静的画像が存在する場合はそれを優先
+    const staticImage = staticCountryImages[countryCode.toLowerCase()];
+    if (staticImage) {
+      return staticImage;
+    }
+
+    // Unsplashサービスを使用して動的に画像を取得
+    return getCountryImageWithFallback(country.nameEn || country.name);
+  } catch (error) {
+    console.warn(`Failed to get image for country ${countryCode}:`, error);
+    return getFallbackImage();
+  }
 };

--- a/project/src/services/unsplashService.ts
+++ b/project/src/services/unsplashService.ts
@@ -1,0 +1,157 @@
+// Unsplash URL generation service for country-specific background images
+// Uses Unsplash Source API which doesn't require API keys
+
+// Generate deterministic Unsplash URLs based on country search terms
+export const generateUnsplashUrl = (searchTerms: string, width = 1200, height = 800): string => {
+  // Use Unsplash Source API to get images by search term
+  // This approach is more reliable and doesn't require API keys
+  const encodedSearch = encodeURIComponent(searchTerms);
+  return `https://source.unsplash.com/${width}x${height}/?${encodedSearch}`;
+};
+
+// Country-specific search terms optimized for beautiful background images
+const getCountrySearchTerms = (countryName: string): string => {
+  const terms: Record<string, string> = {
+    // Major countries with iconic landmarks
+    'japan': 'japan,mount-fuji,cherry-blossom,temple',
+    'korea': 'south-korea,seoul,traditional-architecture,landscape',
+    'france': 'france,paris,eiffel-tower,architecture',
+    'italy': 'italy,venice,architecture,landscape',
+    'germany': 'germany,castle,bavaria,architecture',
+    'uk': 'england,london,architecture,countryside',
+    'usa': 'america,new-york,landscape,landmarks',
+    'china': 'china,great-wall,architecture,landscape',
+    'thailand': 'thailand,temple,bangkok,tropical',
+    'vietnam': 'vietnam,ha-long-bay,landscape,temple',
+    'brazil': 'brazil,rio-de-janeiro,christ-redeemer,landscape',
+    'india': 'india,taj-mahal,architecture,palace',
+    'australia': 'australia,sydney-opera-house,landscape,architecture',
+    'canada': 'canada,rockies,nature,landscape',
+    'spain': 'spain,sagrada-familia,architecture,landscape',
+    'netherlands': 'netherlands,amsterdam,canal,windmill',
+    'finland': 'finland,northern-lights,aurora,nature',
+    'iceland': 'iceland,blue-lagoon,nature,landscape',
+    'norway': 'norway,fjord,northern-lights,nature',
+    'sweden': 'sweden,stockholm,nature,architecture',
+    'denmark': 'denmark,copenhagen,architecture,landscape',
+    'switzerland': 'switzerland,alps,matterhorn,mountain',
+    'austria': 'austria,salzburg,alps,architecture',
+    'portugal': 'portugal,lisbon,architecture,landscape',
+    'greece': 'greece,santorini,islands,architecture',
+    'turkey': 'turkey,istanbul,architecture,landscape',
+    'egypt': 'egypt,pyramids,giza,desert',
+    'morocco': 'morocco,marrakech,architecture,desert',
+    'russia': 'russia,moscow,red-square,architecture',
+    'mexico': 'mexico,chichen-itza,architecture,landscape',
+    'argentina': 'argentina,buenos-aires,patagonia,landscape',
+    'chile': 'chile,atacama-desert,andes,landscape',
+    'peru': 'peru,machu-picchu,mountains,ancient',
+    'new zealand': 'new-zealand,milford-sound,nature,landscape',
+    'philippines': 'philippines,palawan,islands,tropical',
+    'indonesia': 'indonesia,bali,temple,tropical',
+    'malaysia': 'malaysia,kuala-lumpur,petronas-towers,architecture',
+    'singapore': 'singapore,marina-bay,skyline,architecture',
+    'south africa': 'south-africa,cape-town,table-mountain,landscape',
+    'algeria': 'algeria,sahara,desert,landscape',
+    'bhutan': 'bhutan,monastery,mountains,architecture',
+    'maldives': 'maldives,beach,tropical,paradise',
+    'malta': 'malta,valletta,architecture,mediterranean',
+    'luxembourg': 'luxembourg,castle,architecture,landscape',
+    'brunei': 'brunei,mosque,architecture,islamic',
+    'montenegro': 'montenegro,kotor,bay,landscape',
+    'estonia': 'estonia,tallinn,medieval,architecture',
+    'latvia': 'latvia,riga,architecture,baltic',
+    'lithuania': 'lithuania,vilnius,architecture,baltic',
+    'slovenia': 'slovenia,bled,lake,landscape',
+    'cyprus': 'cyprus,coast,mediterranean,landscape',
+    'andorra': 'andorra,mountains,pyrenees,landscape',
+    'san-marino': 'san-marino,towers,architecture,medieval',
+    'monaco': 'monaco,monte-carlo,luxury,architecture',
+    'vatican': 'vatican,st-peters,architecture,basilica',
+    'seychelles': 'seychelles,beach,tropical,paradise',
+    'palau': 'palau,jellyfish-lake,tropical,diving',
+    'tuvalu': 'tuvalu,atoll,pacific,tropical',
+    'nauru': 'nauru,island,pacific,tropical',
+    'kiribati': 'kiribati,atoll,pacific,tropical',
+    'marshall-islands': 'marshall-islands,atoll,pacific,tropical',
+    'micronesia': 'micronesia,diving,pacific,tropical',
+    'tonga': 'tonga,pacific,tropical,islands',
+    'samoa': 'samoa,pacific,tropical,beach',
+    'vanuatu': 'vanuatu,volcano,pacific,tropical',
+    'fiji': 'fiji,tropical,beach,paradise',
+    // Add more countries as needed
+    'afghanistan': 'afghanistan,mountains,landscape,architecture',
+    'albania': 'albania,riviera,mountains,landscape',
+    'armenia': 'armenia,monastery,mountains,architecture',
+    'azerbaijan': 'azerbaijan,baku,caspian,architecture',
+    'bahrain': 'bahrain,manama,architecture,gulf',
+    'bangladesh': 'bangladesh,dhaka,landscape,architecture',
+    'belarus': 'belarus,minsk,architecture,landscape',
+    'belgium': 'belgium,brussels,architecture,medieval',
+    'bosnia': 'bosnia,sarajevo,bridge,architecture',
+    'bulgaria': 'bulgaria,sofia,mountains,architecture',
+    'croatia': 'croatia,dubrovnik,coast,architecture',
+    'czech': 'czech-republic,prague,architecture,castle',
+    'hungary': 'hungary,budapest,danube,architecture',
+    'iran': 'iran,isfahan,mosque,architecture',
+    'iraq': 'iraq,baghdad,mesopotamia,architecture',
+    'israel': 'israel,jerusalem,architecture,landscape',
+    'jordan': 'jordan,petra,desert,ancient',
+    'kazakhstan': 'kazakhstan,almaty,mountains,landscape',
+    'kuwait': 'kuwait,towers,architecture,gulf',
+    'kyrgyzstan': 'kyrgyzstan,mountains,landscape,nature',
+    'lebanon': 'lebanon,beirut,cedars,mountains',
+    'moldova': 'moldova,chisinau,architecture,landscape',
+    'mongolia': 'mongolia,steppe,landscape,nature',
+    'myanmar': 'myanmar,bagan,temple,pagoda',
+    'nepal': 'nepal,everest,himalayas,temple',
+    'oman': 'oman,muscat,architecture,desert',
+    'pakistan': 'pakistan,k2,mountains,landscape',
+    'qatar': 'qatar,doha,skyline,architecture',
+    'saudi arabia': 'saudi-arabia,riyadh,desert,architecture',
+    'serbia': 'serbia,belgrade,architecture,landscape',
+    'slovakia': 'slovakia,bratislava,castle,architecture',
+    'sri lanka': 'sri-lanka,temple,tea-plantation,landscape',
+    'syria': 'syria,damascus,architecture,ancient',
+    'tajikistan': 'tajikistan,mountains,pamir,landscape',
+    'turkmenistan': 'turkmenistan,ashgabat,desert,architecture',
+    'uae': 'uae,dubai,burj-khalifa,architecture',
+    'ukraine': 'ukraine,kiev,architecture,landscape',
+    'uzbekistan': 'uzbekistan,samarkand,architecture,islamic',
+    'yemen': 'yemen,sanaa,architecture,mountains'
+  };
+
+  // Return specific terms or fallback to generic country search
+  return terms[countryName.toLowerCase()] || `${countryName},landscape,nature,architecture`;
+};
+
+// Main function to get country-specific Unsplash image URL
+export const getUnsplashCountryImage = (countryName: string): string => {
+  const searchTerms = getCountrySearchTerms(countryName);
+  return generateUnsplashUrl(searchTerms);
+};
+
+// Alternative function that provides multiple variations
+export const getUnsplashCountryImageVariations = (countryName: string): string[] => {
+  const baseTerms = getCountrySearchTerms(countryName);
+  const variations = [
+    baseTerms,
+    `${countryName},architecture,landmark`,
+    `${countryName},nature,landscape`,
+    `${countryName},city,skyline`,
+    `${countryName},culture,traditional`
+  ];
+
+  return variations.map(terms => generateUnsplashUrl(terms));
+};
+
+// Function to get image with fallback
+export const getCountryImageWithFallback = (countryName: string): string => {
+  try {
+    return getUnsplashCountryImage(countryName);
+  } catch (error) {
+    console.warn(`Failed to generate Unsplash URL for ${countryName}:`, error);
+    // Fallback to existing image
+    return 'https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=1200&h=800&fit=crop&q=80';
+  }
+};


### PR DESCRIPTION
## Summary
- Remove '魅力4選' (4 attractions) section from country pages
- Implement automated Unsplash API integration for country-specific background images
- Create comprehensive search terms for 100+ countries
- Maintain backward compatibility with static images for major countries

## Changes
- `CountryDetailSimple.tsx`: Removed attractions section (lines 165-197)
- `unsplashService.ts`: New service for dynamic image generation
- `countryImages.ts`: Updated to use Unsplash with fallback system

## Test Plan
- Verify attractions section is removed from country pages
- Test background images load correctly for various countries
- Confirm fallback images work when Unsplash is unavailable

Closes #31

🤖 Generated with [Claude Code](https://claude.ai/code)