### PR TITLE
fix: improve country page back navigation with state restoration

### DIFF
--- a/project/src/components/CountryDetailSimple.tsx
+++ b/project/src/components/CountryDetailSimple.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useParams, Link, useNavigate } from 'react-router-dom';
+import { useParams, Link, useNavigate, useLocation } from 'react-router-dom';
 import { ArrowLeft, Sparkles, MapPin, Users, Globe, Home } from 'lucide-react';
 import CountryFlag from './CountryFlag';
 import InteractiveWorldMap from './InteractiveWorldMap';
@@ -9,14 +9,22 @@ import { countryData } from '../data/countries';
 export default function CountryDetailSimple() {
   const { countryCode } = useParams<{ countryCode: string }>();
   const navigate = useNavigate();
+  const location = useLocation();
   const country = countryData[countryCode?.toLowerCase() || ''];
   const [imageLoaded, setImageLoaded] = useState(false);
   
   const handleBack = () => {
-    // 診断結果から来た場合は戻る、そうでなければホームページに移動
-    if (window.history.length > 1) {
-      navigate(-1);
+    // 診断結果の状態が存在する場合は、その状態を復元してホームページに戻る
+    if (location.state?.diagnosisResult) {
+      navigate('/', { 
+        state: { 
+          restoreResult: location.state.diagnosisResult,
+          restoreImage: location.state.userImage,
+          restoreGender: location.state.selectedGender
+        }
+      });
     } else {
+      // 状態がない場合は通常のホームページに戻る
       navigate('/');
     }
   };

--- a/project/src/components/HomePage.tsx
+++ b/project/src/components/HomePage.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { Link } from 'react-router-dom';
+import React, { useState, useEffect } from 'react';
+import { Link, useLocation } from 'react-router-dom';
 import { Sparkles } from 'lucide-react';
 import GenderSelector from './GenderSelector';
 import ImageUpload from './ImageUpload';
@@ -15,7 +15,19 @@ function HomePage() {
   const [selectedImage, setSelectedImage] = useState<File | null>(null);
   const [imagePreview, setImagePreview] = useState<string | null>(null);
   
-  const { isLoading, result, error, diagnose, reset } = useDiagnosis();
+  const location = useLocation();
+  const { isLoading, result, error, diagnose, reset, restore } = useDiagnosis();
+
+  // 国別ページから戻ってきた時の状態復元
+  useEffect(() => {
+    if (location.state?.restoreResult) {
+      restore(location.state.restoreResult);
+      setImagePreview(location.state.restoreImage);
+      setSelectedGender(location.state.restoreGender);
+      // 状態を復元した後、履歴から状態を削除
+      window.history.replaceState({}, document.title);
+    }
+  }, [location.state, restore]);
 
   const handleImageSelect = (file: File) => {
     setSelectedImage(file);

--- a/project/src/components/ResultDisplay.tsx
+++ b/project/src/components/ResultDisplay.tsx
@@ -13,7 +13,7 @@ interface ResultDisplayProps {
   gender: 'male' | 'female';
 }
 
-export default function ResultDisplay({ result, userImage, onReset }: ResultDisplayProps) {
+export default function ResultDisplay({ result, userImage, onReset, gender }: ResultDisplayProps) {
   const topResult = result.ranking[0];
   const otherResults = result.ranking.slice(1, 5); // 2位から5位まで
   const topCountryImage = result.top_country_image_url; // バックエンドから直接URLを取得
@@ -71,6 +71,11 @@ export default function ResultDisplay({ result, userImage, onReset }: ResultDisp
               <div className="mt-4">
                 <Link
                   to={`/country/${countryCode}`}
+                  state={{
+                    diagnosisResult: result,
+                    userImage: userImage,
+                    selectedGender: gender
+                  }}
                   className="inline-flex items-center gap-2 px-6 py-3 bg-white/20 hover:bg-white/30 text-white rounded-full font-medium transition-all duration-300 hover:scale-105"
                 >
                   <ExternalLink size={18} />
@@ -130,6 +135,11 @@ export default function ResultDisplay({ result, userImage, onReset }: ResultDisp
                   {countryCode ? (
                     <Link
                       to={`/country/${countryCode}`}
+                      state={{
+                        diagnosisResult: result,
+                        userImage: userImage,
+                        selectedGender: gender
+                      }}
                       className="flex items-center p-3 bg-gray-50 rounded-lg hover:bg-gray-100 transition-colors duration-200 hover:shadow-md"
                     >
                       <span className="text-lg font-bold text-gray-600 w-8">{index + 2}</span>

--- a/project/src/hooks/useDiagnosis.ts
+++ b/project/src/hooks/useDiagnosis.ts
@@ -28,11 +28,18 @@ export const useDiagnosis = () => {
     setIsLoading(false);
   }, []);
 
+  const restore = useCallback((diagnosisResult: DiagnosisResult) => {
+    setResult(diagnosisResult);
+    setError(null);
+    setIsLoading(false);
+  }, []);
+
   return {
     isLoading,
     result,
     error,
     diagnose,
-    reset
+    reset,
+    restore
   };
 };


### PR DESCRIPTION
## Summary
- Fix back button navigation from country pages to return to results instead of diagnosis page
- Implement React Router state passing to preserve diagnosis results across navigation
- Add state restoration functionality in HomePage component
- Update useDiagnosis hook with restore function for state management

## Changes
- `ResultDisplay.tsx`: Pass diagnosis results via location.state in country links
- `CountryDetailSimple.tsx`: Update back button to restore diagnosis state
- `HomePage.tsx`: Implement state restoration from location.state
- `useDiagnosis.ts`: Add restore function for state management

## Test Plan
- Navigate from diagnosis to results to country page
- Click back button and verify it returns to results page
- Verify diagnosis results are preserved and displayed correctly
- Test browser back button behavior

Closes #31

🤖 Generated with [Claude Code](https://claude.ai/code)